### PR TITLE
Add Shanghai Qibao Dwight High School

### DIFF
--- a/lib/domains/org/qibaodwight.txt
+++ b/lib/domains/org/qibaodwight.txt
@@ -1,0 +1,1 @@
+Shanghai Qibao Dwight High School


### PR DESCRIPTION
We are an international school in Shanghai offering IB/Alevel/IGCSE curriculum.
Our official website is https://www.qibaodwight.org/en
You can find a list of computer science courses we offer here: https://www.qibaodwight.org/index.php/en/Curriculum/
![image](https://user-images.githubusercontent.com/68145229/136492644-96c83797-6fb9-45ec-9986-15887b8b5e7a.png)
